### PR TITLE
Update basic_iarchive.cpp

### DIFF
--- a/src/basic_iarchive.cpp
+++ b/src/basic_iarchive.cpp
@@ -453,7 +453,7 @@ basic_iarchive_impl::load_pointer(
         // class_id_type new_cid = register_type(bpis_ptr->get_basic_serializer());
         BOOST_VERIFY(register_type(bpis_ptr->get_basic_serializer()) == cid);
         int i = cid;
-        cobject_id_vector[i].bpis_ptr = bpis_ptr;
+        cobject_id_vector.at(i).bpis_ptr = bpis_ptr;
     }
     int i = cid;
     cobject_id & co = cobject_id_vector[i];


### PR DESCRIPTION
I had UB while using boost serialization at work, and of course, I have to say, it was caused by incorrect usage of boost::serialize from my side, because I tried to deserialize object of type, that wasn't actually in container. Anyway, I don't think this should be the cause for undefined behaviour. It should throw at least some exception in release build. The problem was detected accidentally in debug build, "subscript out of range" exception was thrown by vector [] operator.

Sorry that I don't have an example of serialization/deserialization that causes the problem. I'm too lazy to simplify our closed code. I hope people that are good at this great library will understand cause of this problem without examples.